### PR TITLE
Get rid of IS_ARM64 flag

### DIFF
--- a/xosp_apps_essentials.mk
+++ b/xosp_apps_essentials.mk
@@ -1,6 +1,6 @@
 #Copy the essentials XOSPApps
 
-ifeq ($(IS_ARM64), TRUE)
+ifeq ($(TARGET_ARCH), arm64)
 
 PRODUCT_COPY_FILES += \
 	essentials_xosp_apps/arm64/textinput-tng/textinput-tng.apk:system/priv-app/textinput-tng/textinput-tng.apk \


### PR DESCRIPTION
Device cpu arch is already defined in BoardConfig, no need to specify it again.